### PR TITLE
Fix: SMAPI 4.1.2 compatibility and bugfixes for v1.2.1

### DIFF
--- a/MatrixFishingUI/Framework/Fish/FishHelper.cs
+++ b/MatrixFishingUI/Framework/Fish/FishHelper.cs
@@ -188,7 +188,7 @@ public static class FishHelper
 
         void AddSpawningCondition(HashSet<Season> seasons, SpawnFishData fish, List<string>? specialConditions = null)
         {
-            if (fish.RandomItemId is not null && fish.RandomItemId.Count <= 0)
+            if (fish.RandomItemId is not null && fish.RandomItemId.Count > 0)
             {
                 foreach (var fishId in fish.RandomItemId)
                 {
@@ -253,6 +253,7 @@ public static class FishHelper
     {
         var conditions = conditionQuery.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         var result = new HashSet<Season>();
+        var sawHere = false;
         foreach (var condition in conditions)
         {
             var split = condition.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -260,7 +261,11 @@ public static class FishHelper
             for (var i = 1; i < split.Length; i++)
             {
                 var rawSeason = split[i];
-                if(rawSeason.Equals("Here", StringComparison.OrdinalIgnoreCase)) continue;
+                if (rawSeason.Equals("Here", StringComparison.OrdinalIgnoreCase))
+                {
+                    sawHere = true;
+                    continue;
+                }
                 if (rawSeason.Equals("spring", StringComparison.OrdinalIgnoreCase)) result.Add(Season.Spring);
                 else if (rawSeason.Equals("summer", StringComparison.OrdinalIgnoreCase)) result.Add(Season.Summer);
                 else if (rawSeason.Equals("fall", StringComparison.OrdinalIgnoreCase)) result.Add(Season.Fall);
@@ -268,9 +273,13 @@ public static class FishHelper
                 else ModEntry.LogError($"Unknown Season caught when parsing: {conditionQuery}, Split: {rawSeason}");
             }
         }
-        
 
-        return result.Count == 0 ? null : result;
+        if (result.Count == 0)
+        {
+            return sawHere ? Enum.GetValues<Season>().ToHashSet() : null;
+        }
+
+        return result;
     }
     
     private static List<string> ParseConditionGeneric(string conditionQuery)

--- a/MatrixFishingUI/Framework/Fish/VanillaProvider.cs
+++ b/MatrixFishingUI/Framework/Fish/VanillaProvider.cs
@@ -128,36 +128,34 @@ public class VanillaProvider : IFishProvider {
 					{
 						case "158":
 						{
-							// UndergroundMine20
-							var floor20 = Game1.RequireLocation("UndergroundMine20");
 							fishInfo.CatchInfo.Locations
 								.Add(new SpawningCondition(
-									new LocationArea(floor20.NameOrUniqueName,"UndergroundMine20", floor20.NameOrUniqueName),
+									new LocationArea("UndergroundMine20", "UndergroundMine20", "UndergroundMine20"),
 									allSeasons.ToList()));
 							break;
 						}
 						case "161":
 						{
-							// UndergroundMine60
-							var floor60 = Game1.RequireLocation("UndergroundMine60");
 							fishInfo.CatchInfo.Locations
 								.Add(new SpawningCondition(
-									new LocationArea(floor60.NameOrUniqueName,"UndergroundMine60", floor60.NameOrUniqueName),
+									new LocationArea("UndergroundMine60", "UndergroundMine60", "UndergroundMine60"),
 									allSeasons.ToList()));
 							break;
 						}
 						case "162":
 						{
-							// UndergroundMine100
-							var floor100 = Game1.RequireLocation("UndergroundMine100");
 							fishInfo.CatchInfo.Locations
 								.Add(new SpawningCondition(
-									new LocationArea(floor100.NameOrUniqueName,"UndergroundMine100", floor100.NameOrUniqueName),
+									new LocationArea("UndergroundMine100", "UndergroundMine100", "UndergroundMine100"),
 									allSeasons.ToList()));
 							break;
 						}
 					}
-					fishInfo.CatchInfo.Difficulty = ParseInt(section, "Difficulty", id, defaultValue: 0);
+					var difficulty = section.Trim();
+					fishInfo.CatchInfo.Difficulty =
+						difficulty.Length == 0 || difficulty.Equals("null", StringComparison.OrdinalIgnoreCase)
+							? 0
+							: ParseInt(difficulty, "Difficulty", id, defaultValue: 0);
 				}
 			}
 
@@ -257,7 +255,7 @@ public class VanillaProvider : IFishProvider {
 		foreach (var pond in pondData)
 		{
 			var matched = true;
-			foreach (var tag in pond.RequiredTags)
+			foreach (var tag in pond.RequiredTags ?? [])
 			{
 				if (fishInfo.Item.HasContextTag(tag)) continue;
 				matched = false;
@@ -288,8 +286,12 @@ public class VanillaProvider : IFishProvider {
 			pondInfo.Initial = initial;
 			pondInfo.ProducedItems = correctPond.ProducedItems
 				.Select(x => x.ItemId)
+				.Where(x => !string.IsNullOrWhiteSpace(x))
 				.Distinct()
-				.Select(x => (x == "812" ? FishHelper.GetRoeForFish((SObject)fishInfo.Item) : ItemRegistry.Create(x, 1)))
+				.Select(x => x == "812"
+					? FishHelper.GetRoeForFish((SObject)fishInfo.Item)
+					: ItemRegistry.Create(x, 1, allowNull: true))
+				.OfType<Item>()
 				.ToList();
 			pondInfo.FishPondRewards = correctPond.ProducedItems;
 		}

--- a/MatrixFishingUI/manifest.json
+++ b/MatrixFishingUI/manifest.json
@@ -1,10 +1,9 @@
 {
-  "Name": "Fish Helper UI",
+  "Name": "Fish Helper UI Unofficial",
   "Author": "Script Kitty",
-  "Version": "1.2.0",
-  "Description": "An in game menu with all related fishing information and a helpful HUD!",
+  "Version": "1.2.2-unofficial.1-meiameiameia",
+  "Description": "Unofficial maintenance release of an in game menu with fishing information and a helpful HUD.",
   "UniqueID": "Borealis.MatrixFishingUI",
   "EntryDll": "MatrixFishingUI.dll",
-  "MinimumApiVersion": "4.1.2",
-  "UpdateKeys": ["Nexus:33167"]
+  "MinimumApiVersion": "4.1.2"
 }


### PR DESCRIPTION
- Fix fish handling for entries that use RandomItemId
- Fix fish pond tag matching when RequiredTags is missing
- Fix LOCATION_Season Here parsing for modded fish data
- Fix fish pond reward processing when produced item ID is null/blank
- Fix null difficulty values in modded fish data
- Fix mines elevator unlock on new saves
- Update manifest: name to 'Fish Helper UI Unofficial', version 1.2.2-unofficial.1-meiameiameia, remove UpdateKeys